### PR TITLE
Use fixed ublox_f9p branch

### DIFF
--- a/config/fusioncore.yaml
+++ b/config/fusioncore.yaml
@@ -20,8 +20,8 @@ fusioncore:
     gnss.base_noise_z: 1.0
     gnss.max_hdop: 4.0
     gnss.min_satellites: 4
-    # The current ublox_f9p driver publishes NavSatFix STATUS_FIX for 3D fixes,
-    # so requiring RTK-specific fix types would starve FusionCore.
+    # ublox_f9p maps RTK fixed to GBAS and RTK float/differential to SBAS,
+    # but allow standalone GNSS so localization can start before corrections converge.
     gnss.min_fix_type: 1
     gnss.velocity_topic: /gps/odom
     gnss.lever_arm_x: 0.32

--- a/config/gps.yaml
+++ b/config/gps.yaml
@@ -8,5 +8,6 @@ ublox_f9p:
     config:
       enabled: true
       measurement_frequency: 5
+      uart_output_rate: 5
     publish:
       motion_odometry: true

--- a/custom_deps.yaml
+++ b/custom_deps.yaml
@@ -10,7 +10,7 @@ repositories:
   ublox_f9p:
     type: git
     url: https://github.com/jkaflik/ublox_f9p
-    version: remove-robot-localization-dependency
+    version: fix/parser-rtk-semantics
   ntrip_client:
     type: git
     url: https://github.com/LORD-MicroStrain/ntrip_client

--- a/launch/gps.launch.py
+++ b/launch/gps.launch.py
@@ -1,14 +1,10 @@
 import os
-import yaml
 from launch import LaunchDescription
-from launch.actions import IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
-from launch_ros.substitutions import FindPackageShare
-from launch.substitutions import LaunchConfiguration
-from launch.actions import DeclareLaunchArgument
 
 from ament_index_python.packages import get_package_share_directory
+
+
 def generate_launch_description():
     nodes = [
         Node(
@@ -35,6 +31,7 @@ def generate_launch_description():
                     'password': os.getenv('OM_NTRIP_PASSWORD', ''),
                     'rtcm_message_package': 'rtcm_msgs',
                 }],
+                remappings=[('fix', '/gps/fix')],
             ),
         )
 

--- a/package.xml
+++ b/package.xml
@@ -61,7 +61,7 @@
   <exec_depend>unique_identifier_msgs</exec_depend>
   <exec_depend>micro_ros_agent</exec_depend>
 
-  <exec_depend>ublox_gps</exec_depend>
+  <exec_depend>ublox_f9p</exec_depend>
   <exec_depend>ntrip_client</exec_depend>
 
   <exec_depend>navigation2</exec_depend>


### PR DESCRIPTION
## Summary
- Point OpenMowerNext at the ublox_f9p parser/RTK fix branch and submodule commit.
- Add the UART output-rate parameter expected by the fixed driver.
- Remap NTRIP client fix feedback to /gps/fix and update package dependency wiring.
- Update FusionCore config comments for ublox RTK status mapping.

## Related
- ublox_f9p PR: https://github.com/jkaflik/ublox_f9p/pull/3

## Verification
- source /opt/ros/jazzy/setup.bash && colcon build --base-paths src/lib/ublox_f9p --cmake-args -DBUILD_TESTING=OFF
- source /opt/ros/jazzy/setup.bash && colcon build --symlink-install --packages-select open_mower_next
- source /opt/ros/jazzy/setup.bash && colcon test --packages-select open_mower_next --ctest-args -LE integration
- colcon test-result --verbose

Hardware GPS/NTRIP runtime verification not run.