### PR TITLE
Wire GPSFix localization and omdev workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@
 - Sim launch from repo root: `make sim`; it sources ROS, the installed workspace, `.devcontainer/default.env`, then launches `open_mower_next sim.launch.py` with Webots.
 - Headless Webots smoke launch: `WEBOTS_OFFSCREEN=1 ros2 launch open_mower_next sim.launch.py gui:=false mode:=fast` after sourcing ROS and `install/setup.bash`.
 - ROS MCP rosbridge foreground launch: `make rosbridge`; user service setup: `make rosbridge-service-enable`.
+- `omdev.local` hardware iteration uses a long-lived `docker.io/library/ros:jazzy` dev container, not the GHCR production image: `make omdev-sync`, `make omdev-dev-start`, `make omdev-deps`, `make omdev-build`, `make omdev-run-workspace`, `make omdev-logs`.
+- If `omdev-build` reports stale generated CMake paths after changing the dev container image, run `make omdev-clean` before rebuilding.
 - Direct ROS package launches use `open_mower_next`, e.g. `ros2 launch open_mower_next openmower.launch.py` or `ros2 launch open_mower_next sim.launch.py`.
 - Docs are isolated under `docs/`: `cd docs && npm ci && npm run docs:build`; dev server is `npm run docs:dev`.
 
@@ -41,6 +43,8 @@
 - `launch/rsp.launch.py` references package `open_mower_ros`, unlike the rest of the repo; verify before relying on `make rsp`.
 - If moving the docking plugin XML, update `src/docking_helper/plugins.xml`, `cmake/docking_helper.cmake`, `package.xml`, and the manual copy in `Dockerfile`.
 - The runtime Docker entrypoint creates an empty GeoJSON map when `OM_MAP_PATH` is missing; normal dev shells do not.
+- Do not use `ghcr.io/jkaflik/openmowernext:*` as the default `omdev.local` iteration image; it can carry stale dependency headers. Use the mutable `docker.io/library/ros:jazzy` dev container and refresh deps from the synced workspace with `make omdev-deps`.
+- Do not run `make custom-deps` inside the `omdev.local` dev container; sync `src/lib` from the dev machine and use `rosdep`/`colcon` there so local vendored branches are not overwritten by `vcs import --force`.
 - Webots is the only supported simulation backend; Gazebo assets and `ros_gz` bridge logic are legacy and should not be reintroduced.
 - Webots launch depends on `webots_ros2_driver`, `webots_ros2_control`, and a Webots binary available on the host.
 - If `webots_ros2_driver` auto-installs Webots, it usually lands in `~/.ros/webotsR2025a/webots`; export `WEBOTS_HOME` to that path or use `make sim`.

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,46 @@ REMOTE_HOST ?= omdev.local
 REMOTE_USER ?= openmower
 ROS_DISTRO ?= jazzy
 ROS_LOG_DIR = log/
+OMDEV_HOST ?= $(REMOTE_HOST)
+OMDEV_USER ?= $(USER)
+OMDEV_SSH ?= $(OMDEV_USER)@$(OMDEV_HOST)
+OMDEV_SSH_OPTS ?=
+OMDEV_RSYNC_SSH ?= ssh $(OMDEV_SSH_OPTS)
+OMDEV_WORKSPACE ?= /home/$(OMDEV_USER)/OpenMowerNext
+OMDEV_MAP_DIR ?= /home/$(OMDEV_USER)/next
+OMDEV_ENV_FILE ?= /home/$(OMDEV_USER)/omnext/openmower.env
+OMDEV_IMAGE ?= docker.io/library/ros:jazzy
+OMDEV_BUILD_IMAGE ?= $(OMDEV_IMAGE)
+OMDEV_CONTAINER_WORKSPACE ?= /target_ws
+OMDEV_FIELDS2COVER_BASE_PATHS ?= src/lib/fields2cover
+OMDEV_FIELDS2COVER_PACKAGES ?= --packages-select fields2cover
+OMDEV_LIB_BASE_PATHS ?= src/lib/vesc src/lib/micro_ros_agent src/lib/ntrip_client src/lib/fusioncore/compass_msgs src/lib/fusioncore/fusioncore_core src/lib/fusioncore/fusioncore_ros src/lib/ublox_f9p
+OMDEV_LIB_PACKAGES ?= --packages-select vesc_msgs vesc_driver vesc_hw_interface vesc micro_ros_agent ntrip_client compass_msgs fusioncore_core fusioncore_ros ublox_f9p
+OMDEV_APP_PACKAGES ?= --packages-select open_mower_next
+OMDEV_CMAKE_ARGS ?= --cmake-args -DBUILD_TESTING=OFF
+OMDEV_FIELDS2COVER_CMAKE_ARGS ?= --cmake-args -DBUILD_TESTING=OFF -DBUILD_TUTORIALS=OFF -DBUILD_PYTHON=OFF -DBUILD_DOC=OFF
+OMDEV_LIB_CMAKE_ARGS ?= $(OMDEV_CMAKE_ARGS)
+OMDEV_APP_CMAKE_ARGS ?= $(OMDEV_CMAKE_ARGS)
+OMDEV_LAUNCH_ARGS ?=
+OMDEV_CONTAINER ?= next-dev
+OMDEV_PODMAN ?= sudo podman
+OMDEV_TOOL_DEPS ?= python3-colcon-common-extensions python3-vcstool python3-rosdep
+OMDEV_ROSDEP_PATHS ?= . $(OMDEV_FIELDS2COVER_BASE_PATHS) $(OMDEV_LIB_BASE_PATHS)
+OMDEV_ROSDEP_SKIP_KEYS ?= webots_ros2_control webots_ros2_driver
+OMDEV_LAUNCH_LOG ?= log/omdev-launch.log
+OMDEV_LAUNCH_PID ?= /tmp/openmowernext-launch.pid
+OMDEV_CLEAN_PATHS ?= build install log
+OMDEV_RSYNC_DELETE ?=
+OMDEV_RSYNC_EXCLUDES = \
+	--exclude .git/ \
+	--exclude '**/.git/' \
+	--exclude build/ \
+	--exclude install/ \
+	--exclude log/ \
+	--exclude .cache/ \
+	--exclude .pytest_cache/ \
+	--exclude docs/node_modules/ \
+	--exclude docs/.vitepress/dist/
 ROSBRIDGE_ADDRESS ?= 127.0.0.1
 ROSBRIDGE_PORT ?= 9090
 ROSBRIDGE_SERVICE ?= openmower-rosbridge.service
@@ -16,7 +56,7 @@ SHELL := /bin/bash
 
 all: custom-deps deps build
 
-.PHONY: deps custom-deps build-libs build build-release sim run dev run-foxglove foxglove foxglove-deps foxglove-service-install foxglove-service-enable foxglove-service-disable foxglove-service-restart foxglove-service-status foxglove-service-logs rsp remote-devices rosbridge rosbridge-deps rosbridge-service-install rosbridge-service-enable rosbridge-service-disable rosbridge-service-restart rosbridge-service-status rosbridge-service-logs
+.PHONY: deps custom-deps build-libs build build-release sim run dev run-foxglove foxglove foxglove-deps foxglove-service-install foxglove-service-enable foxglove-service-disable foxglove-service-restart foxglove-service-status foxglove-service-logs rsp remote-devices omdev omdev-sync omdev-pull omdev-dev-create omdev-dev-recreate omdev-dev-start omdev-dev-stop omdev-deps omdev-clean omdev-run omdev-run-workspace omdev-restart omdev-stop omdev-logs omdev-status omdev-shell omdev-build rosbridge rosbridge-deps rosbridge-service-install rosbridge-service-enable rosbridge-service-disable rosbridge-service-restart rosbridge-service-status rosbridge-service-logs
 
 deps:
 	rosdep install --from-paths . src/lib --ignore-src -i -y -r
@@ -107,3 +147,53 @@ rsp:
 
 remote-devices:
 	bash .devcontainer/scripts/remote_devices.sh $(REMOTE_HOST) $(REMOTE_USER)
+
+omdev: omdev-run-workspace
+
+omdev-sync:
+	ssh $(OMDEV_SSH_OPTS) $(OMDEV_SSH) 'mkdir -p "$(OMDEV_WORKSPACE)" "$(OMDEV_MAP_DIR)" "$$(dirname "$(OMDEV_ENV_FILE)")"'
+	rsync -az --human-readable --info=progress2 $(OMDEV_RSYNC_DELETE) $(OMDEV_RSYNC_EXCLUDES) -e '$(OMDEV_RSYNC_SSH)' ./ "$(OMDEV_SSH):$(OMDEV_WORKSPACE)/"
+
+omdev-pull:
+	ssh $(OMDEV_SSH_OPTS) $(OMDEV_SSH) '$(OMDEV_PODMAN) pull "$(OMDEV_IMAGE)"'
+
+omdev-dev-create:
+	ssh $(OMDEV_SSH_OPTS) $(OMDEV_SSH) 'set -e; mkdir -p "$(OMDEV_WORKSPACE)" "$(OMDEV_MAP_DIR)" "$$(dirname "$(OMDEV_ENV_FILE)")"; if ! $(OMDEV_PODMAN) container exists "$(OMDEV_CONTAINER)"; then env_args=""; if [ -f "$(OMDEV_ENV_FILE)" ]; then env_args="--env-file $(OMDEV_ENV_FILE)"; else echo "warning: $(OMDEV_ENV_FILE) not found; using image defaults for datum"; fi; $(OMDEV_PODMAN) pull "$(OMDEV_IMAGE)"; $(OMDEV_PODMAN) create --name "$(OMDEV_CONTAINER)" --privileged --network host --entrypoint /bin/bash -v /dev:/dev -v "$(OMDEV_WORKSPACE):$(OMDEV_CONTAINER_WORKSPACE)" -v "$(OMDEV_MAP_DIR):/next" -w "$(OMDEV_CONTAINER_WORKSPACE)" $$env_args -e OM_MAP_PATH=/next/map.json "$(OMDEV_IMAGE)" -lc "trap : TERM INT; sleep infinity & wait" >/dev/null; fi'
+
+omdev-dev-recreate:
+	ssh $(OMDEV_SSH_OPTS) $(OMDEV_SSH) '$(OMDEV_PODMAN) rm -f -t 0 "$(OMDEV_CONTAINER)" >/dev/null 2>&1 || true'
+	$(MAKE) omdev-dev-create
+
+omdev-dev-start: omdev-dev-create
+	ssh $(OMDEV_SSH_OPTS) $(OMDEV_SSH) 'set -e; if [ "$$($(OMDEV_PODMAN) inspect -f "{{.State.Running}}" "$(OMDEV_CONTAINER)")" != "true" ]; then $(OMDEV_PODMAN) start "$(OMDEV_CONTAINER)" >/dev/null; fi'
+
+omdev-dev-stop:
+	ssh $(OMDEV_SSH_OPTS) $(OMDEV_SSH) '$(OMDEV_PODMAN) stop "$(OMDEV_CONTAINER)" >/dev/null 2>&1 || true'
+
+omdev-deps: omdev-sync omdev-dev-start
+	ssh $(OMDEV_SSH_OPTS) $(OMDEV_SSH) 'set -e; $(OMDEV_PODMAN) exec -u 0 "$(OMDEV_CONTAINER)" bash -lc "set -e; apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install -y $(OMDEV_TOOL_DEPS); rosdep init >/dev/null 2>&1 || true; rosdep update; source /opt/ros/$(ROS_DISTRO)/setup.bash; cd $(OMDEV_CONTAINER_WORKSPACE); DEBIAN_FRONTEND=noninteractive rosdep install --from-paths $(OMDEV_ROSDEP_PATHS) --ignore-src -i -y -r --skip-keys=\"$(OMDEV_ROSDEP_SKIP_KEYS)\""'
+
+omdev-clean: omdev-dev-start
+	ssh $(OMDEV_SSH_OPTS) $(OMDEV_SSH) '$(OMDEV_PODMAN) exec -u 0 "$(OMDEV_CONTAINER)" bash -lc "cd $(OMDEV_CONTAINER_WORKSPACE) && rm -rf $(OMDEV_CLEAN_PATHS)"'
+
+omdev-run: omdev-run-workspace
+
+omdev-run-workspace: omdev-sync omdev-dev-start
+	ssh $(OMDEV_SSH_OPTS) $(OMDEV_SSH) 'env_args=""; if [ -f "$(OMDEV_ENV_FILE)" ]; then env_args="--env-file $(OMDEV_ENV_FILE)"; fi; $(OMDEV_PODMAN) exec $$env_args "$(OMDEV_CONTAINER)" bash -lc "cd $(OMDEV_CONTAINER_WORKSPACE) && bash utils/omdev-run-launch.sh $(ROS_DISTRO) $(OMDEV_LAUNCH_LOG) $(OMDEV_LAUNCH_PID) $(OMDEV_LAUNCH_ARGS)"'
+
+omdev-restart: omdev-run-workspace
+
+omdev-stop:
+	ssh $(OMDEV_SSH_OPTS) $(OMDEV_SSH) '$(OMDEV_PODMAN) exec "$(OMDEV_CONTAINER)" bash -lc "cd $(OMDEV_CONTAINER_WORKSPACE) && bash utils/omdev-stop-launch.sh $(OMDEV_LAUNCH_PID)"'
+
+omdev-logs: omdev-dev-start
+	ssh -t $(OMDEV_SSH_OPTS) $(OMDEV_SSH) '$(OMDEV_PODMAN) exec -it "$(OMDEV_CONTAINER)" bash -lc "cd $(OMDEV_CONTAINER_WORKSPACE) && touch $(OMDEV_LAUNCH_LOG) && tail -n 200 -f $(OMDEV_LAUNCH_LOG)"'
+
+omdev-status:
+	ssh $(OMDEV_SSH_OPTS) $(OMDEV_SSH) 'hostname; id; test -f "$(OMDEV_ENV_FILE)" && echo "env: $(OMDEV_ENV_FILE)" || echo "env missing: $(OMDEV_ENV_FILE)"; test -f "$(OMDEV_MAP_DIR)/map.json" && echo "map: $(OMDEV_MAP_DIR)/map.json" || echo "map missing: $(OMDEV_MAP_DIR)/map.json"; $(OMDEV_PODMAN) ps -a --filter name="^$(OMDEV_CONTAINER)$$"; $(OMDEV_PODMAN) images "$(OMDEV_IMAGE)"'
+
+omdev-shell:
+	ssh -t $(OMDEV_SSH_OPTS) $(OMDEV_SSH) '$(OMDEV_PODMAN) exec -it "$(OMDEV_CONTAINER)" bash'
+
+omdev-build: omdev-sync omdev-dev-start
+	ssh $(OMDEV_SSH_OPTS) $(OMDEV_SSH) 'set -e; uid=$$(id -u); gid=$$(id -g); $(OMDEV_PODMAN) exec --user "$$uid:$$gid" -e HOME=/tmp "$(OMDEV_CONTAINER)" bash -lc "source /opt/ros/$(ROS_DISTRO)/setup.bash && cd $(OMDEV_CONTAINER_WORKSPACE) && colcon build --symlink-install --base-paths $(OMDEV_FIELDS2COVER_BASE_PATHS) $(OMDEV_FIELDS2COVER_PACKAGES) $(OMDEV_FIELDS2COVER_CMAKE_ARGS) && source install/setup.bash && colcon build --symlink-install --base-paths $(OMDEV_LIB_BASE_PATHS) $(OMDEV_LIB_PACKAGES) $(OMDEV_LIB_CMAKE_ARGS) && source install/setup.bash && colcon build --symlink-install $(OMDEV_APP_PACKAGES) $(OMDEV_APP_CMAKE_ARGS)"'

--- a/config/fusioncore.yaml
+++ b/config/fusioncore.yaml
@@ -5,6 +5,7 @@ fusioncore:
     publish_rate: 50.0
     publish.force_2d: true
     publish.tf: true
+    motion_model: DifferentialDrive
 
     imu.topic: /imu/data
     imu.frame_id: imu
@@ -23,6 +24,7 @@ fusioncore:
     # The current ublox_f9p driver publishes NavSatFix STATUS_FIX for 3D fixes,
     # so requiring RTK-specific fix types would starve FusionCore.
     gnss.min_fix_type: 1
+    gnss.use_gps_fix: false
     gnss.velocity_topic: /gps/odom
     gnss.lever_arm_x: 0.32
     gnss.lever_arm_y: 0.0
@@ -39,6 +41,11 @@ fusioncore:
     gnss.rotation_heading_sigma_floor: 0.05
     gnss.rotation_heading_delta_yaw_sigma: 0.03
     gnss.rotation_heading_max_window_s: 10.0
+    gnss.coast_n: 5
+    gnss.coast_q_factor: 10.0
+    gnss.coast_timeout_s: 30.0
+    gnss.coast_q_bias_factor: 100.0
+    gnss.coast_imu_wz_scale: 500.0
 
     outlier_rejection: true
     outlier_threshold_gnss: 16.27
@@ -46,7 +53,7 @@ fusioncore:
     outlier_threshold_enc: 11.34
     outlier_threshold_hdg: 10.83
 
-    init.stationary_window: 0.0
+    init.stationary_window: 2.0
     init.wait_for_all_sensors: true
     init.sensor_wait_timeout: 10.0
 

--- a/config/gps.yaml
+++ b/config/gps.yaml
@@ -7,6 +7,7 @@ ublox_f9p:
     debug: false
     config:
       enabled: true
-      measurement_frequency: 5
+      measurement_frequency: 10
+      uart_output_rate: 10
     publish:
       motion_odometry: true

--- a/custom_deps.yaml
+++ b/custom_deps.yaml
@@ -22,7 +22,7 @@ repositories:
   fusioncore:
     type: git
     url: https://github.com/jkaflik/fusioncore.git
-    version: openmower/gnss-track-heading-thresholds
+    version: openmower/gnss-rotation-heading-bootstrap
   webots_ros2:
     type: git
     url: https://github.com/jkaflik/webots_ros2.git

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -56,6 +56,7 @@ export default withMermaid({
                 { text: 'CLion alternative', link: '/clion-env' },
               ],
             },
+            { text: 'Hardware target', link: '/hardware-target' },
             { text: 'Visualisation', link: '/visualisation' },
             { text: 'Simulator', link: '/simulator' },
             { text: 'ROS MCP', link: '/ros-mcp' },

--- a/docs/architecture/localization.md
+++ b/docs/architecture/localization.md
@@ -6,12 +6,11 @@ title: FusionCore localization
 ## Overview
 
 Robot pose is based on an absolute position from GPS and relative readings from wheel odometry and IMU.
-Orientation is not known on startup and defaults to 0. 
+Orientation is not known on startup and defaults to 0.
 
-As soon as robot starts moving, orientation is assumed based on robot motion and sensors reading.
-It might take a while to get an accurate orientation. Best to start moving in a straight line and do a few circles.
+FusionCore validates heading from GNSS track motion and, during startup, can also bootstrap heading from a controlled rotation around the GNSS lever arm. Until heading is validated, the GNSS lever-arm correction remains inactive.
 
-Currently, there is no fallback scenario if had its position changed externally. For example, if you move the robot manually, it will not be able to recover position itself. It will require same procedure as on startup. 
+If the robot is moved manually while powered, localization should be reset or restarted before autonomous motion. It will need the same heading validation procedure as on startup.
 
 Later on, when undocking behavior is implemented, it will be possible to recover orientation knowing base station position.
 
@@ -21,6 +20,8 @@ OpenMowerNext uses [FusionCore](https://github.com/manankharwar/fusioncore) for 
 GPS and IMU sensor fusion. FusionCore publishes `/fusion/odom` and the `odom -> base_link` TF.
 The map datum from `OM_DATUM_LAT` and `OM_DATUM_LONG` is used as the fixed FusionCore reference
 origin so the fused odometry aligns with GeoJSON maps.
+
+On hardware, the u-blox F9P driver publishes `gps_msgs/GPSFix` on `/gps/fix_extended` and the hardware launch remaps that into FusionCore. This preserves RTK_FLOAT versus RTK_FIX status, satellite count, and receiver accuracy fields that are not available in `sensor_msgs/NavSatFix`. Simulation still uses `/gps/fix` as `NavSatFix`.
 
 ### Wheel odometry
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,4 +17,4 @@ The goal is to:
 
 - `OM_MAP_PATH` - path to the map file (see: [map server](architecture/map-server.md))
 - `OM_DATUM_LAT` - latitude of the datum point
-- `OM_DATUM_LON` - longitude of the datum point
+- `OM_DATUM_LONG` - longitude of the datum point

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,6 +48,7 @@ Project is tested on YardForce Classic 500B model. It should work on other model
 
 - [Setup as for OpenMower](https://openmower.de/docs/robot-assembly/prepare-the-parts/)
   - [OpenMower v0.13.x mainboard](https://openmower.de/docs/robot-assembly/prepare-the-parts/prepare-mainboard/) with [omros2-firmware](https://github.com/jkaflik/omros2-firmware) flashed. Learn more about the custom firmware in [omros2-firmware](architecture/omros2-firmware).
+- For physical robot testing, see the [hardware target](hardware-target.md) guide. The examples use `omdev.local` as the conventional robot hostname.
 
 ### Software
 

--- a/docs/hardware-target.md
+++ b/docs/hardware-target.md
@@ -1,0 +1,81 @@
+# Hardware Target
+
+`omdev.local` is the conventional example hostname for a physical OpenMowerNext test target on the local network. It is not a required name: replace it with your robot hostname or pass `REMOTE_HOST=...` to the Make targets.
+
+Use this flow when you want to validate OpenMowerNext against real hardware instead of Webots.
+
+## Target Host
+
+A hardware target is usually a small Linux computer mounted on the mower, for example a Raspberry Pi. The host should provide:
+
+- SSH access from the development machine.
+- Access to the robot serial devices under `/dev`.
+- Podman or Docker if using the container runtime.
+- A persistent map directory outside the repository.
+
+The repository defaults to `omdev.local` for remote-device helper commands:
+
+```bash
+make remote-devices
+```
+
+Override it for another robot:
+
+```bash
+make REMOTE_HOST=my-mower.local REMOTE_USER=my-user remote-devices
+```
+
+## Configuration Files
+
+Keep site-specific state outside the repository. A typical target layout is:
+
+```text
+~/next/map.json
+~/omnext/openmower.env
+```
+
+The environment file should provide at least:
+
+```bash
+OM_DATUM_LAT=<latitude>
+OM_DATUM_LONG=<longitude>
+OM_MAP_PATH=/next/map.json
+```
+
+Do not commit private coordinates, credentials, NTRIP settings, or real maps to the repository.
+
+## Container Runtime
+
+The current hardware-oriented runtime is containerized. A simple foreground run looks like this:
+
+```bash
+sudo podman run --rm --name next \
+  --privileged \
+  --network host \
+  -v /dev:/dev \
+  -v "$HOME/next:/next" \
+  --env-file "$HOME/omnext/openmower.env" \
+  ghcr.io/jkaflik/openmowernext:main
+```
+
+Use foreground runs while bringing up a robot. They make launch failures, hardware permissions, and ROS node crashes immediately visible.
+
+## Fast Iteration
+
+For rapid development, avoid rebuilding and pushing the full runtime image for every source change. Prefer this loop:
+
+- Edit and validate on the development machine.
+- Sync the working tree to the hardware target with `rsync`, excluding `build/`, `install/`, and `log/`.
+- Run an incremental `colcon build --symlink-install` on the target or inside a long-lived development container on the target.
+- Launch in the foreground and watch logs before enabling any service or autonomous behavior.
+
+Use a tagged image from GHCR for reproducible runtime tests and systemd/Podman services once the hardware flow is stable.
+
+## Safety
+
+Before launching on real hardware:
+
+- Keep the mower blade physically disabled unless the test explicitly requires it.
+- Put the robot on stands for wheel and controller tests.
+- Start with observation-only launches where possible.
+- Confirm GPS, micro-ROS, VESC, TF, and localization topics before sending motion commands.

--- a/docs/hardware-target.md
+++ b/docs/hardware-target.md
@@ -25,6 +25,23 @@ Override it for another robot:
 make REMOTE_HOST=my-mower.local REMOTE_USER=my-user remote-devices
 ```
 
+The `omdev-*` targets use `omdev.local` through `REMOTE_HOST` by default and the current local username as `OMDEV_USER`:
+
+```bash
+make omdev-status
+make omdev-sync
+make omdev-build
+make omdev-run
+make omdev-logs
+make omdev-stop
+```
+
+Override the target host or user when needed:
+
+```bash
+make OMDEV_HOST=my-mower.local OMDEV_USER=pi omdev-status
+```
+
 ## Configuration Files
 
 Keep site-specific state outside the repository. A typical target layout is:
@@ -42,34 +59,88 @@ OM_DATUM_LONG=<longitude>
 OM_MAP_PATH=/next/map.json
 ```
 
+Use raw `KEY=value` entries in this file. `podman --env-file` passes shell quotes
+literally, so `OM_NTRIP_PASSWORD="secret"` includes the quote characters in the
+password and can cause NTRIP caster `401 Unauthorized` responses.
+
 Do not commit private coordinates, credentials, NTRIP settings, or real maps to the repository.
 
 ## Container Runtime
 
-The current hardware-oriented runtime is containerized. A simple foreground run looks like this:
+`omdev.local` is a mutable hardware-development target. Do not run the production `ghcr.io/jkaflik/openmowernext:*` image there during iteration. The default Makefile flow uses a long-lived `docker.io/library/ros:jazzy` container named `next-dev`, mounts the synced workspace, installs dependencies from that workspace, and launches from the local build output.
+
+Sync the workspace and create or start the dev container:
 
 ```bash
-sudo podman run --rm --name next \
-  --privileged \
-  --network host \
-  -v /dev:/dev \
-  -v "$HOME/next:/next" \
-  --env-file "$HOME/omnext/openmower.env" \
-  ghcr.io/jkaflik/openmowernext:main
+make omdev-sync
+make omdev-dev-start
 ```
 
-Use foreground runs while bringing up a robot. They make launch failures, hardware permissions, and ROS node crashes immediately visible.
+Recreate it after changing the map mount layout, base image, or container options:
+
+```bash
+make omdev-dev-recreate
+```
+
+`omdev-run-workspace` reloads `~/omnext/openmower.env` for the launch process, so changing datum or NTRIP values does not require recreating the dev container.
+
+Install or refresh dependencies inside the dev container after syncing:
+
+```bash
+make omdev-deps
+```
+
+`omdev-deps` installs ROS tooling, runs `rosdep update`, and installs dependencies for the root package plus the hardware-relevant vendored packages. It intentionally does not run `make custom-deps` on the target because `vcs import --force` can overwrite the synced `src/lib` checkouts.
+
+If the ROS base image or generated CMake metadata changes, clean target-side build artifacts before rebuilding:
+
+```bash
+make omdev-clean
+make omdev-build
+```
+
+After `make omdev-sync` and `make omdev-build`, run the synced workspace:
+
+```bash
+make omdev-run-workspace
+make omdev-logs
+```
+
+Pass extra launch arguments during bring-up when needed:
+
+```bash
+make OMDEV_LAUNCH_ARGS='enable_navigation_readiness:=false' omdev-run-workspace
+```
+
+If a non-IMU sensor is intentionally offline during diagnostics, bypass FusionCore's all-sensor startup gate:
+
+```bash
+make OMDEV_LAUNCH_ARGS='enable_navigation_readiness:=false init_wait_for_all_sensors:=false init_stationary_window:=0.0' omdev-run-workspace
+```
+
+FusionCore still initializes from the first IMU sample, so this does not bypass a missing `/imu/data_raw` publisher.
+
+The image can be changed without editing the Makefile:
+
+```bash
+make OMDEV_IMAGE=docker.io/library/ros:jazzy omdev-dev-recreate
+```
 
 ## Fast Iteration
 
-For rapid development, avoid rebuilding and pushing the full runtime image for every source change. Prefer this loop:
+For rapid development, avoid rebuilding and pushing a runtime image for hardware validation. Prefer this loop:
 
 - Edit and validate on the development machine.
-- Sync the working tree to the hardware target with `rsync`, excluding `build/`, `install/`, and `log/`.
-- Run an incremental `colcon build --symlink-install` on the target or inside a long-lived development container on the target.
-- Launch in the foreground and watch logs before enabling any service or autonomous behavior.
+- Sync the working tree to the hardware target with `make omdev-sync`; it excludes `build/`, `install/`, `log/`, docs dependencies, and VCS metadata.
+- Run `make omdev-deps` after dependency changes or after recreating the dev container.
+- Run `make omdev-clean` before rebuilding if the base image changed or stale generated CMake paths appear.
+- Run `make omdev-build` to execute an incremental build of the current branch's hardware-critical packages inside the long-lived dev container.
+- Run `make omdev-run-workspace` to launch the synced and built workspace.
+- Watch logs before enabling any service or autonomous behavior.
 
-Use a tagged image from GHCR for reproducible runtime tests and systemd/Podman services once the hardware flow is stable.
+By default `omdev-build` builds `fields2cover`, `vesc_*`, `micro_ros_agent`, `ntrip_client`, `compass_msgs`, `fusioncore_core`, `fusioncore_ros`, and `ublox_f9p` from `src/lib`, then builds `open_mower_next` from the workspace root. Override `OMDEV_FIELDS2COVER_BASE_PATHS`, `OMDEV_LIB_BASE_PATHS`, `OMDEV_LIB_PACKAGES`, or `OMDEV_APP_PACKAGES` if your change needs a wider build.
+
+Use a tagged GHCR image only for explicit release or production-image validation. `omdev.local` bring-up does not require a system service; run the workspace from the ROS Jazzy dev container while iterating.
 
 ## Safety
 

--- a/launch/localization.launch.py
+++ b/launch/localization.launch.py
@@ -50,6 +50,10 @@ def generate_launch_description():
     gnss_track_heading_min_speed = LaunchConfiguration("gnss_track_heading_min_speed")
     gnss_track_heading_min_dist = LaunchConfiguration("gnss_track_heading_min_dist")
     gnss_heading_observable_distance = LaunchConfiguration("gnss_heading_observable_distance")
+    gnss_use_gps_fix = LaunchConfiguration("gnss_use_gps_fix")
+    gnss_fix_topic = LaunchConfiguration("gnss_fix_topic")
+    init_stationary_window = LaunchConfiguration("init_stationary_window")
+    init_wait_for_all_sensors = LaunchConfiguration("init_wait_for_all_sensors")
     datum_lat = require_env_float("OM_DATUM_LAT")
     datum_lon = require_env_float("OM_DATUM_LONG")
     datum_x, datum_y, datum_z = wgs84_to_ecef(datum_lat, datum_lon)
@@ -82,12 +86,17 @@ def generate_launch_description():
                 "gnss.heading_observable_distance": ParameterValue(
                     gnss_heading_observable_distance, value_type=float
                 ),
+                "gnss.use_gps_fix": ParameterValue(gnss_use_gps_fix, value_type=bool),
+                "init.stationary_window": ParameterValue(init_stationary_window, value_type=float),
+                "init.wait_for_all_sensors": ParameterValue(
+                    init_wait_for_all_sensors, value_type=bool
+                ),
             },
         ],
         remappings=[
             ("/imu/data", "/imu/data_raw"),
             ("/odom/wheels", "/diff_drive_base_controller/odom"),
-            ("/gnss/fix", "/gps/fix"),
+            ("/gnss/fix", gnss_fix_topic),
         ],
     )
 
@@ -124,22 +133,9 @@ def generate_launch_description():
             # Set env var to print messages to stdout immediately
             SetEnvironmentVariable("RCUTILS_LOGGING_BUFFERED_STREAM", "1"),
             DeclareLaunchArgument(
-                "namespace", default_value="", description="Top-level namespace"
-            ),
-            DeclareLaunchArgument(
                 "use_sim_time",
                 default_value="false",
                 description="Use simulation clock if true",
-            ),
-            DeclareLaunchArgument(
-                "autostart",
-                default_value="true",
-                description="Automatically startup the nav2 stack",
-            ),
-            DeclareLaunchArgument(
-                "params_file",
-                default_value=os.path.join(package_path, "config", "nav2_params.yaml"),
-                description="Full path to the ROS2 parameters file to use",
             ),
             DeclareLaunchArgument(
                 "gnss_base_noise_xy",
@@ -160,6 +156,26 @@ def generate_launch_description():
                 "gnss_heading_observable_distance",
                 default_value="5.0",
                 description="Valid GNSS track distance before enabling GNSS lever-arm correction",
+            ),
+            DeclareLaunchArgument(
+                "gnss_use_gps_fix",
+                default_value="false",
+                description="Subscribe to gps_msgs/GPSFix instead of sensor_msgs/NavSatFix",
+            ),
+            DeclareLaunchArgument(
+                "gnss_fix_topic",
+                default_value="/gps/fix",
+                description="GNSS fix topic remapped into FusionCore /gnss/fix",
+            ),
+            DeclareLaunchArgument(
+                "init_stationary_window",
+                default_value="2.0",
+                description="Seconds of stationary IMU data to collect before FusionCore init",
+            ),
+            DeclareLaunchArgument(
+                "init_wait_for_all_sensors",
+                default_value="true",
+                description="Wait for every configured FusionCore sensor before initialization",
             ),
             Node(
                 package="tf2_ros",

--- a/launch/openmower.launch.py
+++ b/launch/openmower.launch.py
@@ -3,10 +3,19 @@ import os
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
-from launch.actions import EmitEvent, ExecuteProcess, IncludeLaunchDescription, RegisterEventHandler
+from launch.actions import (
+    DeclareLaunchArgument,
+    EmitEvent,
+    ExecuteProcess,
+    IncludeLaunchDescription,
+    RegisterEventHandler,
+)
+from launch.conditions import IfCondition, UnlessCondition
 from launch.event_handlers import OnProcessStart, OnProcessExit
 from launch.events import Shutdown
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+from launch_xml.launch_description_sources import XMLLaunchDescriptionSource
 
 from launch_ros.actions import Node
 
@@ -17,6 +26,11 @@ def generate_launch_description():
     package_name = 'open_mower_next'
 
     share_directory = get_package_share_directory(package_name)
+    enable_foxglove = LaunchConfiguration('enable_foxglove')
+    foxglove_address = LaunchConfiguration('foxglove_address')
+    foxglove_port = LaunchConfiguration('foxglove_port')
+    enable_navigation_readiness = LaunchConfiguration('enable_navigation_readiness')
+
     xacro_file = os.path.join(share_directory, 'description/robot.urdf.xacro')
     robot_description_config = xacro.process_file(xacro_file, mappings={
         'use_ros2_control': '1',
@@ -78,14 +92,37 @@ def generate_launch_description():
         executable='navigation_readiness_node',
         output='screen',
         parameters=[{'use_sim_time': False, 'timeout_seconds': 120.0}],
+        condition=IfCondition(enable_navigation_readiness),
     )
 
-    nav2 = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([share_directory, '/launch/nav2.launch.py']),
+    def make_nav2(condition=None):
+        return IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([share_directory, '/launch/nav2.launch.py']),
+            launch_arguments={
+                'use_sim_time': 'false',
+                'autostart': 'true',
+            }.items(),
+            condition=condition,
+        )
+
+    nav2 = make_nav2()
+    nav2_without_readiness = make_nav2(UnlessCondition(enable_navigation_readiness))
+
+    foxglove_bridge = IncludeLaunchDescription(
+        XMLLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory('foxglove_bridge'),
+                'launch',
+                'foxglove_bridge_launch.xml',
+            )
+        ),
         launch_arguments={
+            'address': foxglove_address,
+            'port': foxglove_port,
+            'include_hidden': 'true',
             'use_sim_time': 'false',
-            'autostart': 'true',
         }.items(),
+        condition=IfCondition(enable_foxglove),
     )
 
     def start_nav2_or_shutdown(event, context):
@@ -97,6 +134,11 @@ def generate_launch_description():
 
     # Launch them all!
     return LaunchDescription([
+        DeclareLaunchArgument('enable_foxglove', default_value='true'),
+        DeclareLaunchArgument('foxglove_address', default_value='0.0.0.0'),
+        DeclareLaunchArgument('foxglove_port', default_value='8765'),
+        DeclareLaunchArgument('enable_navigation_readiness', default_value='true'),
+
         node_robot_state_publisher,
         twist_mux,
         controller_manager,
@@ -130,21 +172,26 @@ def generate_launch_description():
             PythonLaunchDescriptionSource([share_directory, '/launch/localization.launch.py']),
             launch_arguments={
                 'use_sim_time': 'false',
-                'autostart': 'true',
+                'gnss_use_gps_fix': 'true',
+                'gnss_fix_topic': '/gps/fix_extended',
             }.items(),
         ),
 
         navigation_readiness,
+        nav2_without_readiness,
 
         RegisterEventHandler(
             event_handler=OnProcessExit(
                 target_action=navigation_readiness,
                 on_exit=start_nav2_or_shutdown,
-            )
+            ),
+            condition=IfCondition(enable_navigation_readiness),
         ),
 
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
                 [share_directory, '/launch/micro_ros_agent.launch.py']),
         ),
+
+        foxglove_bridge,
     ])

--- a/launch/sim.launch.py
+++ b/launch/sim.launch.py
@@ -10,7 +10,7 @@ from launch.actions import (
     OpaqueFunction,
     RegisterEventHandler,
 )
-from launch.conditions import IfCondition
+from launch.conditions import IfCondition, UnlessCondition
 from launch.event_handlers import OnProcessExit
 from launch.events import Shutdown
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -47,6 +47,7 @@ def launch_setup(context, *args, **kwargs):
     enable_foxglove = LaunchConfiguration("enable_foxglove")
     foxglove_address = LaunchConfiguration("foxglove_address")
     foxglove_port = LaunchConfiguration("foxglove_port")
+    enable_navigation_readiness = LaunchConfiguration("enable_navigation_readiness")
 
     xacro_file = os.path.join(share_directory, "description", "robot.urdf.xacro")
     robot_description_config = xacro.process_file(
@@ -147,28 +148,37 @@ def launch_setup(context, *args, **kwargs):
         PythonLaunchDescriptionSource(os.path.join(share_directory, "launch", "localization.launch.py")),
         launch_arguments={
             "use_sim_time": use_sim_time,
-            "autostart": "true",
             "gnss_base_noise_xy": "0.05",
             "gnss_track_heading_min_speed": "0.10",
             "gnss_track_heading_min_dist": "1.0",
             "gnss_heading_observable_distance": "1.0",
+            "gnss_use_gps_fix": "false",
+            "gnss_fix_topic": "/gps/fix",
+            "init_stationary_window": "0.0",
+            "init_wait_for_all_sensors": "true",
         }.items(),
     )
 
-    nav2 = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(os.path.join(share_directory, "launch", "nav2.launch.py")),
-        launch_arguments={
-            "use_sim_time": use_sim_time,
-            "autostart": "true",
-            "params_file": os.path.join(share_directory, "config", "nav2_params.yaml"),
-        }.items(),
-    )
+    def make_nav2(condition=None):
+        return IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(os.path.join(share_directory, "launch", "nav2.launch.py")),
+            launch_arguments={
+                "use_sim_time": use_sim_time,
+                "autostart": "true",
+                "params_file": os.path.join(share_directory, "config", "nav2_params.yaml"),
+            }.items(),
+            condition=condition,
+        )
+
+    nav2 = make_nav2()
+    nav2_without_readiness = make_nav2(UnlessCondition(enable_navigation_readiness))
 
     navigation_readiness = Node(
         package="open_mower_next",
         executable="navigation_readiness_node",
         output="screen",
         parameters=[{"use_sim_time": use_sim_time, "timeout_seconds": 120.0}],
+        condition=IfCondition(enable_navigation_readiness),
     )
 
     def start_nav2_or_shutdown(event, context):
@@ -213,11 +223,13 @@ def launch_setup(context, *args, **kwargs):
         sim_node,
         localization,
         navigation_readiness,
+        nav2_without_readiness,
         RegisterEventHandler(
             event_handler=OnProcessExit(
                 target_action=navigation_readiness,
                 on_exit=start_nav2_or_shutdown,
-            )
+            ),
+            condition=IfCondition(enable_navigation_readiness),
         ),
         foxglove_bridge,
         RegisterEventHandler(
@@ -247,6 +259,7 @@ def generate_launch_description():
             DeclareLaunchArgument("enable_foxglove", default_value="false"),
             DeclareLaunchArgument("foxglove_address", default_value="0.0.0.0"),
             DeclareLaunchArgument("foxglove_port", default_value="8765"),
+            DeclareLaunchArgument("enable_navigation_readiness", default_value="true"),
             OpaqueFunction(function=launch_setup),
         ]
     )

--- a/utils/omdev-run-launch.sh
+++ b/utils/omdev-run-launch.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ros_distro="$1"
+launch_log="$2"
+pid_file="$3"
+shift 3
+
+bash utils/omdev-stop-launch.sh "$pid_file" >/dev/null 2>&1 || true
+
+mkdir -p "$(dirname "$launch_log")"
+: > "$launch_log"
+
+setsid bash -c '
+  set -euo pipefail
+  ros_distro="$1"
+  shift
+  set +u
+  source "/opt/ros/${ros_distro}/setup.bash"
+  source install/setup.bash
+  set -u
+  exec ros2 launch open_mower_next openmower.launch.py "$@"
+' omdev-launch "$ros_distro" "$@" >> "$launch_log" 2>&1 &
+
+pid="$!"
+printf '%s\n' "$pid" > "$pid_file"
+printf 'Started OpenMowerNext launch pid %s; log: %s\n' "$pid" "$launch_log"

--- a/utils/omdev-stop-launch.sh
+++ b/utils/omdev-stop-launch.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pid_file="${1:-/tmp/openmowernext-launch.pid}"
+
+if [ ! -f "$pid_file" ]; then
+  printf 'No OpenMowerNext launch pid file at %s\n' "$pid_file"
+  exit 0
+fi
+
+pid=""
+read -r pid < "$pid_file" || true
+rm -f "$pid_file"
+
+if [ -z "$pid" ]; then
+  printf 'OpenMowerNext launch pid file was empty\n'
+  exit 0
+fi
+
+if ! kill -0 "$pid" 2>/dev/null; then
+  printf 'OpenMowerNext launch pid %s is not running\n' "$pid"
+  exit 0
+fi
+
+kill_tree() {
+  local parent="$1"
+  local child
+  for child in $(pgrep -P "$parent" 2>/dev/null || true); do
+    kill_tree "$child"
+    kill -TERM "$child" 2>/dev/null || true
+  done
+}
+
+kill -TERM -- "-$pid" 2>/dev/null || true
+kill_tree "$pid"
+kill -TERM "$pid" 2>/dev/null || true
+sleep 2
+if kill -0 "$pid" 2>/dev/null; then
+  kill -KILL -- "-$pid" 2>/dev/null || true
+  kill_tree "$pid"
+  kill -KILL "$pid" 2>/dev/null || true
+fi
+
+printf 'Stopped OpenMowerNext launch pid %s\n' "$pid"


### PR DESCRIPTION
Draft stacked PR. Base: spinoff/webots-gnss-tests.\n\nScope:\n- Route hardware FusionCore through gps_msgs/GPSFix on /gps/fix_extended.\n- Add omdev sync/build/run workflow and hardware target docs.\n- Document hardware datum/map/env flow.\n\nKnown review notes:\n- Hardware GPSFix path still needs direct test coverage.\n- Public defaults should be checked for private host/IP leakage before ready.